### PR TITLE
Add IRevitAppData & IRevitContext on RevitContainerCommand

### DIFF
--- a/src/Revit/IRevitContext.cs
+++ b/src/Revit/IRevitContext.cs
@@ -38,6 +38,14 @@ namespace Onbox.Revit.VDev
         /// </summary>
         void UnhookRevitEvents(UIControlledApplication application);
         /// <summary>
+        /// Hooks up Revit Events to the context
+        /// </summary>
+        void HookupRevitEvents(UIApplication application);
+        /// <summary>
+        /// Unhooks Revit Events to the context
+        /// </summary>
+        void UnhookRevitEvents(UIApplication application);
+        /// <summary>
         /// Identifies if Revit is in the current context (Revit API context)
         /// </summary>
         bool IsInRevitContext();

--- a/src/Revit/RevitContext.cs
+++ b/src/Revit/RevitContext.cs
@@ -84,6 +84,36 @@ namespace Onbox.Revit.VDev
             // Makes sure to unhook the ViewChanged event and get rid of reference to uiApplication
             UnhookViewChanged();
         }
+
+        /// <summary>
+        /// Hooks up Revit Events to the context
+        /// </summary>
+        public void HookupRevitEvents(UIApplication application)
+        {
+            if (application?.ActiveUIDocument is UIDocument uIDocument)
+            {
+                UpdateContext(uIDocument.Document);
+            }
+            application.Application.DocumentCreated += OnDocumentCreated;
+            application.Application.DocumentChanged += OnDocumentChanged;
+            application.Application.DocumentOpened += OnDocumentOpened;
+            application.Application.DocumentClosed += OnDocumentClosed;
+        }
+
+        /// <summary>
+        /// Unhooks Revit Events to the context
+        /// </summary>
+        public void UnhookRevitEvents(UIApplication application)
+        {
+            application.Application.DocumentCreated -= this.OnDocumentCreated;
+            application.Application.DocumentChanged -= this.OnDocumentChanged;
+            application.Application.DocumentOpened -= this.OnDocumentOpened;
+            application.Application.DocumentClosed -= this.OnDocumentClosed;
+
+            // Makes sure to unhook the ViewChanged event and get rid of reference to uiApplication
+            UnhookViewChanged();
+        }
+
         private void OnDocumentCreated(object sender, Autodesk.Revit.DB.Events.DocumentCreatedEventArgs e)
         {
             var doc = e.Document;


### PR DESCRIPTION
Hello Thiago,

I was testing some codes and found this problem.

<img width="310" alt="OnBox Error" src="https://user-images.githubusercontent.com/12437519/99850859-e1c98c80-2b5c-11eb-90d6-567f03c68469.PNG">

I was trying to open a View using a Command with `RevitContainerCommand<ContainerPipeline>`.

`IRevitAppData` and `IRevitContext` is missing on the `RevitContainerCommandBase`.

**To fix that.**

I used the `UIApplication` from the `ExternalCommandData commandData` to: 

Add `RevitAppData` and `RevitContext` on the container.

On the `RevitContext` I set the active document to `UpdateContext` and add the `HookupRevitContext` / `UnhookRevitContext`. 

_(I don't know if makes sense to add these change events on the Command Container.)_ 

Great job on the Framework!

See yaa!
